### PR TITLE
update to Python 3, `networkx`, and misc changes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,17 +2,17 @@
 """Library and CLI for learning about XML formats."""
 
 # Copyright (C) 2010  Ted Tibbetts
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -20,7 +20,7 @@ from lxml import etree
 
 class Dumper(object):
     """Dump an lxml.etree tree starting at `element`.
-    
+
     Attributes:
         maxdepth: the maximum recursion level.
         width: the width at which text will be wrapped.
@@ -39,7 +39,7 @@ class Dumper(object):
 
     from sys import stdout
     outstream = stdout
-        
+
     from pprint import PrettyPrinter
     pformat = PrettyPrinter(indent=2).pformat
 
@@ -55,7 +55,7 @@ class Dumper(object):
 
         If a `ruleset` is given, that ruleset's rules are output.
         If no `ruleset` is given, a list of rulesets is output.
-        
+
         The `verbose` option will cause full ruleset information
           to be given in the list of rulesets.
 
@@ -96,8 +96,8 @@ class Dumper(object):
     def format_element(self, element, depth, linebreak=False, with_text=True):
         from textwrap import dedent
         title = getattr(element.find('title'), 'text', '')
-        title = (title if title 
-                       else '[{0}]'.format(element.tag 
+        title = (title if title
+                       else '[{0}]'.format(element.tag
                                            if hasattr(element, 'tag') else ''))
         path = (element.getroottree().getpath(element)
                 if hasattr(element, 'getroottree')
@@ -114,7 +114,7 @@ class Dumper(object):
 
     def dump(self, element, **kwargs):
         """Dump `element` according to `ruleset`.
-        
+
         Keyword arguments:
             depth: the initial depth of the dump.  Normally this will be 0.
 
@@ -228,7 +228,7 @@ def iter_tag_list(bases):
 
 def build_tag_graph(bases):
     """Build a python-graph graph of the tag relationships.
-    
+
     `bases` is an element or iterable of elements.
     """
     from pygraph.classes.digraph import digraph

--- a/__init__.py
+++ b/__init__.py
@@ -126,7 +126,7 @@ class Dumper(object):
         I suspect that actually using XSLT would be a better way to do this.
         """
         from copy import copy
-        from collections import Mapping
+        from collections.abc import Mapping
 
         depth = kwargs.pop('depth', 0)
         # Pull variables from kwargs or self
@@ -136,19 +136,19 @@ class Dumper(object):
         ruleset = kwargs.pop('ruleset', getattr(self, 'ruleset',
                                                 self.default_ruleset))
 
-        if isinstance(ruleset, basestring):
+        if isinstance(ruleset, str):
             ruleset = self.rulesets[ruleset]
         assert isinstance(ruleset, Mapping)
 
         def _dump(element, depth=0):
-            for rule in ruleset.iteritems():
+            for rule in ruleset.items():
                 if rule[0] == None:
                     default = copy(rule[1])
                 elif rule[0] == element.tag:
                     kwargs = copy(rule[1])
                     break
             else:
-                assert vars().has_key('default')
+                assert 'default' in vars()
                 kwargs = default
 
             recurse = kwargs.pop('recurse', False)
@@ -190,7 +190,7 @@ def iter_unique_child_tags(bases, tags):
     #   so we need to check for those specific types.
     bases, tags = (iter((param,)) if isinstance(param, type) else iter(param)
                    for (param, type) in ((bases, etree._Element),
-                                         (tags, basestring)))
+                                         (tags, str)))
 
     from itertools import product
     basetags = product(bases, tags)
@@ -285,7 +285,7 @@ def cli(args, in_, out, err, Dumper=Dumper):
     from argparse import ArgumentParser, FileType, Action
 
     parser = ArgumentParser()
-    parser.add_argument('-i', '--infile', type=FileType, default=in_,
+    parser.add_argument('-i', '--infile', type=FileType(), default=in_,
                         help='The XML file to learn about.\n'
                              'Defaults to stdin.')
     parser.add_argument('-p', '--path', default='/*', type=etree.XPath,
@@ -301,7 +301,7 @@ def cli(args, in_, out, err, Dumper=Dumper):
 
         def instantiate_dumper(ns):
             kw_from_ns = ['width', 'maxdepth', 'ruleset', 'outstream']
-            kwargs = dict((key, value) for key, value in ns.__dict__.iteritems()
+            kwargs = dict((key, value) for key, value in ns.__dict__.items()
                                        if key in kw_from_ns and value is not None)
             return ns.Dumper(**kwargs)
 

--- a/__init__.py
+++ b/__init__.py
@@ -231,12 +231,12 @@ def build_tag_graph(bases):
 
     `bases` is an element or iterable of elements.
     """
-    from pygraph.classes.digraph import digraph
+    import networkx as nx
 
-    g = digraph()
+    g = nx.DiGraph()
 
     tags = list(iter_tag_list(bases))
-    g.add_nodes(tags)
+    g.add_nodes_from(tags)
 
     # TODO: this is totally inefficient:
     #         it makes more sense to do each base separately,
@@ -244,7 +244,7 @@ def build_tag_graph(bases):
     #       The better way is to build the set of all bases' edges.
     for tag in tags:
         for child in iter_unique_child_tags(bases, tag):
-            g.add_edge((tag, child))
+            g.add_edge(tag, child)
 
     return g
 
@@ -253,11 +253,8 @@ def write_graph(graph, filename, format='svg'):
 
     `format` can be any of those supported by pydot.Dot.write().
     """
-    from pygraph.readwrite.dot import write
-    dotdata = write(graph)
-
-    from pydot import graph_from_dot_data
-    dotgraph = graph_from_dot_data(dotdata)
+    import networkx as nx
+    dotgraph = nx.drawing.nx_pydot.to_pydot(graph)
     dotgraph.write(filename, format=format)
 
 def write_tag_graph(bases, filename, format='png'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+lxml>=4.5.2
+networkx>=2.5
+pydot>=1.4.1


### PR DESCRIPTION
- update to Python 3
- use `networkx`, instead of `pygraph` (which does not run on Python 3)
- mv imports to top of module
- add `requirements.txt` for `pip install -r requirements.txt`
- rm trailing whitespace [PEP 8]